### PR TITLE
Add missing prompt argument in live_grepper rg writer

### DIFF
--- a/lua/telescope/_extensions/fzf_writer.lua
+++ b/lua/telescope/_extensions/fzf_writer.lua
@@ -42,7 +42,7 @@ return require('telescope').register_extension {
             return nil
           end
 
-          local rg_args = flatten { conf.vimgrep_arguments, "." }
+          local rg_args = flatten { conf.vimgrep_arguments, prompt, "." }
           table.remove(rg_args, 1)
 
           return {


### PR DESCRIPTION
I might be wrong here but I believe this is a typo. So I have this mapping:
```lua
remap('n', '<space>fg', ':lua require("telescope").extensions.fzf_writer.grep()<CR>', { noremap = true })
```
and it would take forever to load (probably because RG is returning all the files for FZF to filter). Basically this is the before and after (recordings because I know how much @tjdevries likes light backgrounds :grin: ):

| Before  | After |
| ------------- | ------------- |
| ![fzf_before-2021-06-01](https://user-images.githubusercontent.com/2808092/120395325-1c468a00-c335-11eb-9d61-34258eae298a.gif)  | ![fzf_after-2021-06-01](https://user-images.githubusercontent.com/2808092/120395357-27011f00-c335-11eb-90c3-da6546aa5355.gif)  |